### PR TITLE
Filter workspace tabs to remove file on load. vsmejkal/chrome-workspa…

### DIFF
--- a/src/service/WorkspaceOpenService.js
+++ b/src/service/WorkspaceOpenService.js
@@ -51,6 +51,8 @@ async function openWorkspace(workspaceId, currentWindow) {
 }
 
 async function createNewWindow(workspace, currentWindow) {
+    workspace.tabs = workspace.tabs.filter(tab => !tab.url.startsWith("file"))
+
     const createArgs = {
         url: workspace.tabs.map(tab => tab.url),
         focused: true,


### PR DESCRIPTION
Issue #29, simple filter to stop it loading file tabs (fixes those that already have workspaces with file saved)